### PR TITLE
feat: add Dockerfile and Docker usage documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY mimicker/ ./mimicker/
+
+RUN pip install --no-cache-dir .
+
+EXPOSE 8080
+
+CMD ["python", "-c", "from mimicker.mimicker import mimicker; import signal; s = mimicker(8080); signal.pause()"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY pyproject.toml README.md ./
+COPY pyproject.toml ./
 COPY mimicker/ ./mimicker/
 
 RUN pip install --no-cache-dir .

--- a/README.md
+++ b/README.md
@@ -376,6 +376,59 @@ This will show detailed request information including method, path, headers, and
 
 ---
 
+## Docker
+
+Mimicker is available as a Docker image for easy use in containerized environments.
+
+### Build the Image
+
+```bash
+docker build -t mimicker .
+```
+
+### Run with a Stub File
+
+Create a `stubs.py` file to define your routes:
+
+```python
+from mimicker.mimicker import mimicker, get, post
+import signal
+
+server = mimicker(8080).routes(
+    get("/hello").body({"message": "Hello, World!"}).status(200),
+    post("/submit").body({"result": "OK"}).status(201),
+)
+
+signal.pause()
+```
+
+Then mount it into the container:
+
+```bash
+docker run -p 8080:8080 -v ./stubs.py:/app/stubs.py mimicker python /app/stubs.py
+```
+
+### Extend the Image
+
+You can also use the Mimicker image as a base for your own:
+
+```dockerfile
+FROM mimicker
+
+COPY stubs.py .
+CMD ["python", "stubs.py"]
+```
+
+### Environment Variables
+
+- `MIMICKER_LOG_LEVEL` — Set the log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Defaults to `INFO`.
+
+```bash
+docker run -p 8080:8080 -e MIMICKER_LOG_LEVEL=DEBUG -v ./stubs.py:/app/stubs.py mimicker python /app/stubs.py
+```
+
+---
+
 ## Requirements
 Mimicker supports Python 3.7 and above.
 


### PR DESCRIPTION
**Summary**

- Add a Dockerfile to enable running Mimicker as a container, useful for integration testing and CI environments
- Add a Docker section to README.md documenting how to build, run with mounted stubs, extend the image, and configure via environment variables

**Details**

The Dockerfile uses python:3.12-slim and installs the package via pip directly (leveraging the poetry-core build backend), keeping the image small and free of unnecessary tooling.

By default the container starts an empty Mimicker server on port 8080. Users can define their routes by mounting a Python stub file:

```bash
docker run -p 8080:8080 -v ./stubs.py:/app/stubs.py mimicker python /app/stubs.py
```

Or by extending the image with their own Dockerfile.

Test plan

  - `docker build -t mimicker .` - completes successfully
  - `docker run -p 8080:8080 mimicker` - starts the server (returns 404 with no routes configured)
  - Mounting a `stubs.py` with GET/POST routes responds correctly (curl returns expected JSON) - described in README