### PR TITLE
feat: add rate limiting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ development, and CI environments.
 - Create HTTP stubs for various endpoints and methods
 - Mock responses with specific status codes, headers, and body content
 - Flexible configuration for multiple endpoints
+- Simulate rate limiting with configurable thresholds, windows, and 429 responses
 
 ## Installation
 
@@ -305,6 +306,66 @@ mimicker(8080).routes(
 # POST /greet with empty body -> {"message": "Hello Guest"}
 ```
 
+### Rate Limiting
+
+Mimicker can simulate rate-limited APIs — useful for testing how your code handles HTTP 429 (Too Many Requests) responses.
+
+```python
+from mimicker.mimicker import mimicker, get
+
+mimicker(8080).routes(
+    get("/api/data")
+    .body({"data": "ok"})
+    .status(200)
+    .rate_limit(max_requests=3, window_seconds=60)
+)
+
+# The first 3 requests to /api/data within 60 seconds return 200 with {"data": "ok"}
+# The 4th request returns 429 Too Many Requests
+```
+
+#### Customizing the Rate Limit Response
+
+You can customize the status code, body, and headers sent when the rate limit is exceeded:
+
+```python
+from mimicker.mimicker import mimicker, get
+
+mimicker(8080).routes(
+    get("/api/data")
+    .body({"data": "ok"})
+    .rate_limit(
+        max_requests=5,
+        window_seconds=60,
+        status_code=429,
+        body={"error": "rate_limit_exceeded", "retry_after": 60},
+        headers=[("Retry-After", "60"), ("Content-Type", "application/json")]
+    )
+)
+
+# Exceeding 5 requests per minute returns:
+# Status: 429
+# Body: {"error": "rate_limit_exceeded", "retry_after": 60}
+# Headers: Retry-After: 60
+```
+
+#### Per-Client Rate Limiting
+
+Rate limits can be keyed by a request header (e.g. `X-Api-Key`) so different clients have independent counters:
+
+```python
+from mimicker.mimicker import mimicker, get
+
+mimicker(8080).routes(
+    get("/api/users")
+    .body({"users": ["alice", "bob"]})
+    .rate_limit(max_requests=10, window_seconds=60, key_header="X-Api-Key")
+)
+
+# Client A (X-Api-Key: key-a) can make 10 requests per minute
+# Client B (X-Api-Key: key-b) can also make 10 requests per minute — independently
+```
+
 ### Using a Random Port
 
 If you start Mimicker with port `0`, the system will automatically assign an available port. You can retrieve the actual port Mimicker is running on using the `get_port` method:
@@ -337,6 +398,7 @@ This is useful for test environments where a specific port is not required.
 * `.status(code)`: Defines the response `status code`.
 * `.headers(headers)`: Defines response `headers`.
 * `.response_func(func)`: Defines a dynamic response function based on the request data.
+* `.rate_limit(max_requests, window_seconds, key_header, status_code, body, headers)`: Simulates rate limiting with a sliding window counter. Returns a configurable 429 response when exceeded.
 
 ---
 

--- a/mimicker/handler.py
+++ b/mimicker/handler.py
@@ -44,7 +44,7 @@ class MimickerHandler(http.server.SimpleHTTPRequestHandler):
         )
 
         if matched_stub:
-            self._send_response(matched_stub, path_params,
+            self._send_response(matched_stub, method, path_params,
                                 parse_qs(urlparse(self.path).query), request_body,
                                 request_headers)
         else:
@@ -62,10 +62,31 @@ class MimickerHandler(http.server.SimpleHTTPRequestHandler):
             f"\nBody:\n{body_str}" if body_str else ""
         )
 
-    def _send_response(self, matched_stub: Stub, path_params: Dict[str, str],
+    def _send_response(self, matched_stub: Stub, method: str,
+                       path_params: Dict[str, str],
                        query_params: Dict[str, List[str]], request_body: Any,
                        request_headers: Dict[str, str]):
-        status_code, delay, response, response_func, headers = matched_stub
+        if matched_stub.rate_limit:
+            key_header_val = request_headers.get(
+                matched_stub.rate_limit.key_header.lower()
+            ) if matched_stub.rate_limit.key_header else ""
+            tracker_key = f"{method}:{urlparse(self.path).path}:{key_header_val}"
+            allowed, remaining, reset_time = self.stub_matcher.rate_limiter.is_allowed(
+                tracker_key,
+                matched_stub.rate_limit.max_requests,
+                matched_stub.rate_limit.window_seconds,
+            )
+            if not allowed:
+                rl = matched_stub.rate_limit
+                self.send_response(rl.status_code)
+                if rl.headers:
+                    for header_name, header_value in rl.headers:
+                        self.send_header(header_name, header_value)
+                self.end_headers()
+                self._write_response(rl.body, path_params)
+                return
+
+        status_code, delay, response, response_func, headers, _ = matched_stub
         if delay > 0:
             sleep(delay)
         if response_func:

--- a/mimicker/rate_limit.py
+++ b/mimicker/rate_limit.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass, field
+from time import time
+from typing import Any, Dict, List, Optional, Tuple
+
+
+@dataclass
+class RateLimitConfig:
+    max_requests: int
+    window_seconds: float
+    key_header: Optional[str] = None
+    status_code: int = 429
+    body: Any = None
+    headers: Optional[List[Tuple[str, str]]] = None
+
+
+class RateLimitTracker:
+    def __init__(self):
+        self._windows: Dict[str, List[float]] = {}
+
+    def is_allowed(
+        self, key: str, max_requests: int, window_seconds: float
+    ) -> Tuple[bool, int, int]:
+        now = time()
+        cutoff = now - window_seconds
+        timestamps = self._windows.get(key, [])
+        timestamps = [t for t in timestamps if t > cutoff]
+        remaining = max_requests - len(timestamps)
+        reset_time = int(now) + int(window_seconds)
+        if remaining > 0:
+            timestamps.append(now)
+            self._windows[key] = timestamps
+            return True, remaining - 1, reset_time
+        return False, 0, reset_time
+
+    def reset(self):
+        self._windows.clear()

--- a/mimicker/route.py
+++ b/mimicker/route.py
@@ -1,6 +1,7 @@
 import re
-from typing import Dict, Tuple, Any, Callable, Optional, Pattern, Union, List
+from typing import Any, Callable, Dict, List, Optional, Pattern, Tuple, Union
 
+from mimicker.rate_limit import RateLimitConfig
 from mimicker.regex import parse_endpoint_pattern
 
 
@@ -25,6 +26,7 @@ class Route:
         self._headers: List[Tuple[str, str]] = []
         self._response_func: Optional[Callable[..., Tuple[int, Any]]] = None
         self._compiled_path: Pattern = parse_endpoint_pattern(path)
+        self._rate_limit: Optional[RateLimitConfig] = None
 
     def delay(self, delay: float):
         """
@@ -92,6 +94,40 @@ class Route:
         self._response_func = func
         return self
 
+    def rate_limit(
+        self,
+        max_requests: int = 10,
+        window_seconds: float = 60.0,
+        key_header: Optional[str] = None,
+        status_code: int = 429,
+        body: Any = None,
+        headers: Optional[List[Tuple[str, str]]] = None,
+    ):
+        """
+        Configures rate limiting for this route.
+
+        Args:
+            max_requests: Maximum number of requests allowed within the window.
+            window_seconds: Time window in seconds.
+            key_header: Optional request header to key rate limits by (e.g. "X-Api-Key").
+            status_code: HTTP status code to return when rate limited.
+            body: Response body when rate limited.
+            headers: Response headers when rate limited.
+
+        Returns:
+            Route: The current Route instance (for method chaining).
+        """
+        self._rate_limit = RateLimitConfig(
+            max_requests=max_requests,
+            window_seconds=window_seconds,
+            key_header=key_header,
+            status_code=status_code,
+            body=body if body is not None else {"error": "Too Many Requests"},
+            headers=headers or [("Retry-After", str(int(window_seconds))),
+                                ("Content-Type", "application/json")],
+        )
+        return self
+
     def build(self):
         """
         Builds the route configuration dictionary.
@@ -107,5 +143,6 @@ class Route:
             "body": self._body,
             "status": self._status,
             "headers": self._headers,
-            "response_func": self._response_func
+            "response_func": self._response_func,
+            "rate_limit": self._rate_limit,
         }

--- a/mimicker/server.py
+++ b/mimicker/server.py
@@ -55,7 +55,8 @@ class MimickerServer:
                 delay=route_config["delay"],
                 response=route_config["body"],
                 headers=route_config["headers"],
-                response_func=route_config["response_func"]
+                response_func=route_config["response_func"],
+                rate_limit=route_config["rate_limit"]
             )
         return self
 

--- a/mimicker/stub_group.py
+++ b/mimicker/stub_group.py
@@ -1,6 +1,7 @@
 from typing import Pattern, Dict, Tuple, Any, Optional, Callable, Union, List, \
     NamedTuple
 
+from mimicker.rate_limit import RateLimitConfig, RateLimitTracker
 from mimicker.regex import parse_endpoint_pattern
 
 
@@ -8,8 +9,9 @@ class Stub(NamedTuple):
     status_code: int
     delay: float
     response: Any
-    response_func: Optional[Callable]
-    headers: Optional[List[Tuple[str, str]]]
+    response_func: Optional[Callable] = None
+    headers: Optional[List[Tuple[str, str]]] = None
+    rate_limit: Optional[RateLimitConfig] = None
 
 
 class StubGroup:
@@ -18,11 +20,13 @@ class StubGroup:
             str,
             Dict[Pattern, Stub]
         ] = {}
+        self.rate_limiter = RateLimitTracker()
 
     def add(self, method: str, pattern: Union[str, Pattern],
             status_code: int, response: Any, delay: Optional[float] = 0,
             response_func: Optional[Callable[[], Tuple[int, Any]]] = None,
-            headers: Optional[List[Tuple[str, str]]] = None):
+            headers: Optional[List[Tuple[str, str]]] = None,
+            rate_limit: Optional[RateLimitConfig] = None):
         if method not in self.stubs:
             self.stubs[method] = {}
 
@@ -30,7 +34,7 @@ class StubGroup:
             pattern = parse_endpoint_pattern(pattern)
 
         self.stubs[method][pattern] = Stub(status_code, delay, response, response_func,
-                                           headers)
+                                           headers, rate_limit)
 
     def match(self, method: str, path: str,
               request_headers: Optional[Dict[str, str]] = None) -> Tuple[
@@ -38,23 +42,21 @@ class StubGroup:
         matched_stub = None
         path_params = {}
 
-        for compiled_path, (status_code, delay, response, response_func, headers) \
-                in self.stubs.get(method, {}).items():
+        for compiled_path, stub in self.stubs.get(method, {}).items():
             match = compiled_path.match(path)
             if match:
                 headers_included = True
-                if headers and request_headers:
+                if stub.headers and request_headers:
                     headers_included = all(
                         header_name in request_headers
                         and request_headers[header_name] == header_value
-                        for header_name, header_value in headers
+                        for header_name, header_value in stub.headers
                     )
 
-                if headers and not headers_included:
+                if stub.headers and not headers_included:
                     pass
 
-                matched_stub = Stub(status_code, delay, response, response_func,
-                                    headers)
+                matched_stub = stub
                 path_params = match.groupdict()
                 break
 

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,169 @@
+from time import sleep
+
+from hamcrest import assert_that, is_, has_entry, not_none
+from hamcrest.library.number.ordering_comparison import greater_than_or_equal_to
+
+from pytest import mark
+
+from mimicker.mimicker import get
+from mimicker.rate_limit import RateLimitTracker, RateLimitConfig
+from tests.support.client import Client
+
+
+class TestRateLimitTracker:
+    def test_allows_requests_within_limit(self):
+        tracker = RateLimitTracker()
+        allowed, remaining, _ = tracker.is_allowed("key", 3, 10)
+        assert_that(allowed, is_(True))
+        assert_that(remaining, is_(2))
+
+    def test_blocks_requests_exceeding_limit(self):
+        tracker = RateLimitTracker()
+        for _ in range(3):
+            tracker.is_allowed("key", 3, 10)
+        allowed, remaining, _ = tracker.is_allowed("key", 3, 10)
+        assert_that(allowed, is_(False))
+        assert_that(remaining, is_(0))
+
+    def test_allows_requests_to_different_keys_independently(self):
+        tracker = RateLimitTracker()
+        for _ in range(3):
+            tracker.is_allowed("key-a", 3, 10)
+        allowed, _, _ = tracker.is_allowed("key-b", 3, 10)
+        assert_that(allowed, is_(True))
+
+    def test_resets_after_window_expires(self):
+        tracker = RateLimitTracker()
+        for _ in range(3):
+            tracker.is_allowed("key", 3, 0.1)
+        allowed, _, _ = tracker.is_allowed("key", 3, 0.1)
+        assert_that(allowed, is_(False))
+        sleep(0.11)
+        allowed, remaining, _ = tracker.is_allowed("key", 3, 0.1)
+        assert_that(allowed, is_(True))
+        assert_that(remaining, is_(2))
+
+    def test_remaining_decrements_correctly(self):
+        tracker = RateLimitTracker()
+        _, r1, _ = tracker.is_allowed("key", 5, 10)
+        _, r2, _ = tracker.is_allowed("key", 5, 10)
+        _, r3, _ = tracker.is_allowed("key", 5, 10)
+        assert_that(r1, is_(4))
+        assert_that(r2, is_(3))
+        assert_that(r3, is_(2))
+
+    def test_reset_clears_all_windows(self):
+        tracker = RateLimitTracker()
+        for _ in range(3):
+            tracker.is_allowed("key", 3, 10)
+        tracker.reset()
+        allowed, _, _ = tracker.is_allowed("key", 3, 10)
+        assert_that(allowed, is_(True))
+
+
+class TestRouteRateLimit:
+    def test_rate_limit_within_limit_returns_normal_response(self, mimicker_server):
+        mimicker_server.routes(
+            get("/api/data")
+            .body({"ok": True})
+            .status(200)
+            .rate_limit(max_requests=3, window_seconds=10)
+        )
+        client = Client()
+        resp = client.get("/api/data")
+        assert_that(resp.status_code, is_(200))
+        assert_that(resp.json(), is_({"ok": True}))
+
+    def test_rate_limit_exceeded_returns_429(self, mimicker_server):
+        mimicker_server.routes(
+            get("/api/data")
+            .body({"ok": True})
+            .status(200)
+            .rate_limit(max_requests=2, window_seconds=10)
+        )
+        client = Client()
+        client.get("/api/data")
+        client.get("/api/data")
+        resp = client.get("/api/data")
+        assert_that(resp.status_code, is_(429))
+
+    def test_rate_limit_default_body(self, mimicker_server):
+        mimicker_server.routes(
+            get("/api/data")
+            .body({"ok": True})
+            .rate_limit(max_requests=1, window_seconds=10)
+        )
+        client = Client()
+        client.get("/api/data")
+        resp = client.get("/api/data")
+        assert_that(resp.json(), is_({"error": "Too Many Requests"}))
+
+    def test_rate_limit_default_headers(self, mimicker_server):
+        mimicker_server.routes(
+            get("/api/data")
+            .body({"ok": True})
+            .rate_limit(max_requests=1, window_seconds=10)
+        )
+        client = Client()
+        client.get("/api/data")
+        resp = client.get("/api/data")
+        assert_that(resp.headers, has_entry("Retry-After", "10"))
+
+    def test_rate_limit_recovers_after_window(self, mimicker_server):
+        mimicker_server.routes(
+            get("/api/data")
+            .body({"ok": True})
+            .rate_limit(max_requests=1, window_seconds=0.1)
+        )
+        client = Client()
+        client.get("/api/data")
+        client.get("/api/data")
+        sleep(0.15)
+        resp = client.get("/api/data")
+        assert_that(resp.status_code, is_(200))
+
+    def test_rate_limit_with_key_header(self, mimicker_server):
+        mimicker_server.routes(
+            get("/api/data")
+            .body({"ok": True})
+            .rate_limit(max_requests=1, window_seconds=10, key_header="X-Api-Key")
+        )
+        client = Client()
+        resp1 = client.get("/api/data", headers={"X-Api-Key": "key-a"})
+        resp2 = client.get("/api/data", headers={"X-Api-Key": "key-a"})
+        resp3 = client.get("/api/data", headers={"X-Api-Key": "key-b"})
+        assert_that(resp1.status_code, is_(200))
+        assert_that(resp2.status_code, is_(429))
+        assert_that(resp3.status_code, is_(200))
+
+    def test_rate_limit_custom_429_body_and_status(self, mimicker_server):
+        mimicker_server.routes(
+            get("/api/data")
+            .body({"ok": True})
+            .rate_limit(
+                max_requests=1, window_seconds=10,
+                status_code=429,
+                body={"custom": "rate_limited"},
+                headers=[("X-Custom", "val"), ("Content-Type", "application/json")]
+            )
+        )
+        client = Client()
+        client.get("/api/data")
+        resp = client.get("/api/data")
+        assert_that(resp.status_code, is_(429))
+        assert_that(resp.json(), is_({"custom": "rate_limited"}))
+
+    def test_rate_limit_does_not_affect_other_routes(self, mimicker_server):
+        mimicker_server.routes(
+            get("/limited")
+            .body({"from": "limited"})
+            .rate_limit(max_requests=1, window_seconds=10),
+            get("/unlimited")
+            .body({"from": "unlimited"})
+        )
+        client = Client()
+        client.get("/limited")
+        # unlimited should still work
+        resp = client.get("/unlimited")
+        assert_that(resp.status_code, is_(200))
+        assert_that(resp.json(), is_({"from": "unlimited"}))

--- a/tests/test_stub_group.py
+++ b/tests/test_stub_group.py
@@ -20,7 +20,7 @@ def test_match():
     stub_group = StubGroup()
     stub_group.add("GET", "/hi", 200, {"message": "hello"})
     matched, _ = stub_group.match("GET", "/hi")
-    assert_that(matched, is_((200, 0., {"message": "hello"}, None, None)))
+    assert_that(matched, is_((200, 0., {"message": "hello"}, None, None, None)))
 
 
 def test_none_on_partial_match():
@@ -39,7 +39,7 @@ def test_match_w_path_param():
 
     matched, path_param = stub_group.match("GET", "/hello/mimicker")
 
-    assert_that(matched, is_((200, 0., {"message": "Hello, {name}!"}, None, None)))
+    assert_that(matched, is_((200, 0., {"message": "Hello, {name}!"}, None, None, None)))
     assert_that(path_param, is_({"name": "mimicker"}))
 
 
@@ -52,7 +52,7 @@ def test_match_w_explicit_query_param_matches_query_param():
 
     matched, path_param = stub_group.match("GET", "/hello/mimicker?greeting=world")
     
-    assert_that(matched, is_((200, 0., {"message": "Hello, {name}!"}, None, None)))
+    assert_that(matched, is_((200, 0., {"message": "Hello, {name}!"}, None, None, None)))
     assert_that(path_param, is_({"name": "world"}))
 
 
@@ -74,7 +74,7 @@ def test_match_w_delay():
 
     matched, _ = stub_group.match("GET", "/hi")
 
-    assert_that(matched, is_((200, 3., {"message": "hello"}, None, None)))
+    assert_that(matched, is_((200, 3., {"message": "hello"}, None, None, None)))
 
 
 def test_match_stub_with_response_func():
@@ -86,7 +86,7 @@ def test_match_stub_with_response_func():
     stub_group.add("GET", "/dynamic",
                    200, {}, response_func=dynamic_response)
     matched, _ = stub_group.match("GET", "/dynamic")
-    assert_that(matched, is_((200, 0., {}, dynamic_response, None)))
+    assert_that(matched, is_((200, 0., {}, dynamic_response, None, None)))
 
 
 def test_match_given_unexpected_header():
@@ -98,7 +98,7 @@ def test_match_given_unexpected_header():
         "GET", "/hi",
         request_headers={"Content-Type": "application/json"})
     assert_that(matched, is_((200, 0., {'message': 'hello'}, None,
-                              [('Content-Type', 'text/plain')])))
+                              [('Content-Type', 'text/plain')], None)))
 
 
 def test_match_given_partial_expected_headers():
@@ -115,6 +115,6 @@ def test_match_given_partial_expected_headers():
         request_headers={"Content-Type": "application/json"})
     assert_that(matched, is_((200, 0., {'message': 'hello'},
                               None, [
-                                  ('Content-Type', 'application/json'),
-                                  ('Authorization', 'Bearer YOUR_TOKEN'),
-                                  ('Custom-Header', 'CustomValue')])))
+                                  ('Content-Type', "application/json"),
+                                  ('Authorization', "Bearer YOUR_TOKEN"),
+                                  ('Custom-Header', "CustomValue")], None)))


### PR DESCRIPTION
## Summary

Adds rate limiting support to Mimicker, allowing users to simulate rate-limited APIs in their tests.

Closes #37

### Key changes

- **New `mimicker/rate_limit.py`** — `RateLimitConfig` dataclass and `RateLimitTracker` with sliding window implementation
- **`mimicker/route.py`** — Added `.rate_limit()` builder method with configurable parameters
- **`mimicker/stub_group.py`** — `Stub` gains `rate_limit` field; `StubGroup` owns a `RateLimitTracker`
- **`mimicker/handler.py`** — `_send_response()` checks rate limit before responding, returns 429 if exceeded
- **`mimicker/server.py`** — Passes `rate_limit` config through to `stub_matcher.add()`
- **`tests/test_rate_limit.py`** — 14 new tests (unit + integration)

### API

```python
# Basic rate limiting
get("/api/data")
    .body({"data": "ok"})
    .rate_limit(max_requests=3, window_seconds=60)

# Custom 429 response
get("/api/data")
    .rate_limit(max_requests=5, window_seconds=60,
                status_code=429, body={"error": "rate limited"},
                headers=[("Retry-After", "60")])

# Per-client (keyed by header)
get("/api/data")
    .rate_limit(max_requests=10, window_seconds=60, key_header="X-Api-Key")
```

All 97 tests pass.
